### PR TITLE
Bumped version of microstates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3169,6 +3169,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/funcadelic/-/funcadelic-0.4.2.tgz",
       "integrity": "sha512-873Yw96Xx3SWNpdG8/z9w00kMIrZeBCcWCVwI0P5bBur/nkQTZhOmLfNCiaIQ9t9E/2eEt9IyWZL4Jsz1VuL6g==",
+      "dev": true,
       "requires": {
         "invariant": "2.2.4",
         "lodash.curry": "4.1.1"
@@ -3178,6 +3179,7 @@
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -3206,6 +3208,26 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
+    },
+    "get-prototype-descriptors": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/get-prototype-descriptors/-/get-prototype-descriptors-0.6.0.tgz",
+      "integrity": "sha512-b6DB4hHG7Eq8jnmr2LP+h4v+Y1DfjoSxZ1BwTBycixsWw6/bXBuhxzhZcnWgVGz6YOFGVNHoi37nxt+OIlzFwQ==",
+      "dev": true,
+      "requires": {
+        "invariant": "2.2.4"
+      },
+      "dependencies": {
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
     },
     "get-stream": {
       "version": "3.0.0",
@@ -4464,7 +4486,8 @@
     "lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
+      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA=",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -4520,6 +4543,15 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memoize-getters": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memoize-getters/-/memoize-getters-1.1.0.tgz",
+      "integrity": "sha512-F/v4OV6SZV9YC2bEIIS0bNy0u3kuCWiFK9UrGtmJn/axFk/roypuoe53w6vrCZzenjLzexpTl20SCT7xrPKopg==",
+      "dev": true,
+      "requires": {
+        "get-prototype-descriptors": "0.6.0"
+      }
+    },
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
@@ -4554,6 +4586,19 @@
         "object.omit": "^2.0.0",
         "parse-glob": "^3.0.4",
         "regex-cache": "^0.4.2"
+      }
+    },
+    "microstates": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/microstates/-/microstates-0.7.2.tgz",
+      "integrity": "sha512-uiyxqvetQh2dOdWrxEmAN0xCCqdvUaRepXUaQRJo26eilfxvxewLAXpejQSH5r8n8CQmCguGEifM+4evTDkAzg==",
+      "dev": true,
+      "requires": {
+        "funcadelic": "0.4.2",
+        "get-prototype-descriptors": "0.6.0",
+        "memoize-getters": "1.1.0",
+        "ramda": "^0.25.0",
+        "symbol-observable": "1.2.0"
       }
     },
     "mime-db": {
@@ -5102,6 +5147,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
       "dev": true
     },
     "randexp": {
@@ -5839,6 +5890,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -49,15 +49,14 @@
     "rollup": "0.56.3",
     "rollup-plugin-babel": "^4.0.0-beta.0",
     "rollup-plugin-filesize": "1.5.0",
-    "microstates": "^0.7.0"
+    "microstates": "^0.7.2"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
-    "microstates": "^0.7.0"
+    "microstates": "^0.7.2"
   },
   "dependencies": {
     "create-react-context": "0.2.2",
-    "funcadelic": "0.4.2",
     "prop-types": "15.6.1"
   }
 }

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { create } from 'microstates';
+import { create, map } from 'microstates';
 import createReactContext from 'create-react-context';
-import { map } from 'funcadelic';
 
 const Context = createReactContext(null);
 


### PR DESCRIPTION
`@microstates/react` now uses `Microstate.map` to installed middleware instead of Funcadelic.