### PR TITLE
Use store instead of observable

### DIFF
--- a/tests/render-test.js
+++ b/tests/render-test.js
@@ -90,6 +90,6 @@ describe('onChange invocation', () => {
 
     wrapper.find('button').simulate('click');
 
-    expect(onChange).toHaveBeenCalledWith(43);
+    expect(onChange.mock.calls[0][0].state).toBe(43);
   });
 });


### PR DESCRIPTION
This PR changes how the next state is captured on transition and applied to the microstate. Instead of using `@@observable` entry point, we're using Store. There is a breaking change in this PR. The onChange callback is called with the entire microstate not just the value. To extract the value, you must take state of the passed microstate.